### PR TITLE
fix(spec-05.5): resolve remaining DevEx bugs (BUG-009, BUG-012)

### DIFF
--- a/docs/bugs/BUG-009-font-loading-silent-fallback.md
+++ b/docs/bugs/BUG-009-font-loading-silent-fallback.md
@@ -2,7 +2,7 @@
 
 ## Severity: P3 (Low Priority) - DevEx
 
-## Status: Open
+## Status: **Fixed**
 
 ## Description
 

--- a/docs/bugs/BUG-012-download-silent-auth.md
+++ b/docs/bugs/BUG-012-download-silent-auth.md
@@ -2,7 +2,7 @@
 
 ## Severity: P3 (Low Priority) - DevEx
 
-## Status: Open
+## Status: **Fixed**
 
 ## Description
 

--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -34,10 +34,10 @@ The unit test suite is **not** “bogus”: mocking OpenSlide is an intentional 
 | [BUG-001](./BUG-001-boundary-crop-no-handling.md) | Boundary Behavior Not Explicitly Specified (Pad vs Clamp) | **Fixed** (documented + tested) |
 | [BUG-007](./BUG-007-entire-test-suite-mocked.md) | Prior "bogus tests" claim was inaccurate (see doc) | Closed (Doc corrected) |
 | [BUG-008](./BUG-008-api-keys-silent-none.md) | Missing "required key" guardrails at use sites | **Fixed** |
-| [BUG-009](./BUG-009-font-loading-silent-fallback.md) | Font Loading Falls Back Silently | Open (DevEx) |
+| [BUG-009](./BUG-009-font-loading-silent-fallback.md) | Font Loading Falls Back Silently | **Fixed** |
 | [BUG-010](./BUG-010-mpp-nullable-no-guards.md) | Optional MPP Needs Helper/Guards When Used | Open (Future) |
 | [BUG-011](./BUG-011-unused-geometry-validator.md) | GeometryValidator Is Staged for Spec-09 (Not Dead) | Open (Deferred) |
-| [BUG-012](./BUG-012-download-silent-auth.md) | HF Download Auth Behavior Not Surfaced | Open (DevEx) |
+| [BUG-012](./BUG-012-download-silent-auth.md) | HF Download Auth Behavior Not Surfaced | **Fixed** |
 
 ## Key Findings
 
@@ -78,7 +78,7 @@ The unit test suite is **not** “bogus”: mocking OpenSlide is an intentional 
 
 ### CAN DEFER
 
-- **BUG-009, BUG-010, BUG-011, BUG-012**: Non-blocking (DevEx/future-proofing)
+- **BUG-010, BUG-011**: Non-blocking (future-proofing / staged for Spec-09)
 
 ### FIXED
 
@@ -88,6 +88,8 @@ The unit test suite is **not** “bogus”: mocking OpenSlide is an intentional 
 - **BUG-004**: Integration tests with opt-in WSI file testing
 - **BUG-005**: Comprehensive single-level slide unit tests
 - **BUG-008**: ConfigError and require_*_key() methods added
+- **BUG-009**: Warning logged when font falls back to default
+- **BUG-012**: Debug log when HF token is not set
 
 ## Audit Methodology
 

--- a/src/giant/data/download.py
+++ b/src/giant/data/download.py
@@ -10,12 +10,15 @@ This module is intentionally minimal for Spec-01:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from huggingface_hub import hf_hub_download
 
 from giant.config import settings
 from giant.utils.logging import configure_logging, get_logger
+
+logger = logging.getLogger(__name__)
 
 MULTIPATHQA_REPO_ID = "tbuckley/MultiPathQA"
 MULTIPATHQA_CSV_FILENAME = "MultiPathQA.csv"
@@ -29,13 +32,21 @@ def download_multipathqa_metadata(
 ) -> Path:
     """Download MultiPathQA metadata CSV to the local `data/` directory."""
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    token = settings.HUGGINGFACE_TOKEN
+    if token is None:
+        logger.debug(
+            "HUGGINGFACE_TOKEN not set, using anonymous access. "
+            "Set token in .env for private/gated datasets."
+        )
+
     csv_path = hf_hub_download(
         repo_id=MULTIPATHQA_REPO_ID,
         filename=MULTIPATHQA_CSV_FILENAME,
         repo_type="dataset",
         local_dir=output_dir,
         force_download=force,
-        token=settings.HUGGINGFACE_TOKEN or None,
+        token=token,
     )
     return Path(csv_path)
 

--- a/src/giant/geometry/overlay.py
+++ b/src/giant/geometry/overlay.py
@@ -11,6 +11,7 @@ intervals and labeling them with their corresponding Level-0 coordinates.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,8 @@ from PIL import Image, ImageDraw, ImageFont
 
 if TYPE_CHECKING:
     from giant.wsi.types import WSIMetadata
+
+logger = logging.getLogger(__name__)
 
 # Threshold for K notation in coordinate labels
 _COORD_THRESHOLD_LARGE = 10000  # Use "15K" for >= 10000
@@ -185,6 +188,11 @@ class AxisGuideGenerator:
                 return ImageFont.truetype("Arial.ttf", self.style.font_size)
             except OSError:
                 # Fall back to PIL's default font
+                logger.warning(
+                    "No TrueType fonts available (DejaVuSans.ttf, Arial.ttf). "
+                    "Using low-resolution default font. Install fonts for better "
+                    "quality."
+                )
                 return ImageFont.load_default()
 
     def _format_coordinate(self, coord: int) -> str:

--- a/src/giant/wsi/reader.py
+++ b/src/giant/wsi/reader.py
@@ -71,7 +71,7 @@ class WSIReader:
         """
         self._path = Path(path).resolve()
         self._metadata: WSIMetadata | None = None
-        self._slide: openslide.OpenSlide | None
+        self._slide: openslide.OpenSlide | None = None
 
         # Validate file exists
         if not self._path.exists():


### PR DESCRIPTION
## Summary

- Fix BUG-009: Add warning when font falls back to PIL's default bitmap font
- Fix BUG-012: Add debug log when HuggingFace token is not set
- Address CodeRabbit feedback: initialize `_slide = None` in WSIReader.__init__

## Changes

### BUG-009 (Font Fallback Warning)
- `AxisGuideGenerator._get_font()` now logs a warning when falling back to PIL's default font
- Helps users understand why overlay labels may look pixelated

### BUG-012 (HF Token Debug Log)  
- `download_multipathqa_metadata()` now logs at DEBUG level when no token is set
- Clarifies auth status and guides users to set HUGGINGFACE_TOKEN for gated datasets

### CodeRabbit Fix
- `WSIReader._slide` now initialized to `None` before validation
- Ensures attribute exists even if exception raised during __init__

## Bug Status After This PR

| Bug | Status |
|-----|--------|
| BUG-001 through BUG-009 | **Fixed** |
| BUG-010 | Deferred (MPP not used yet) |
| BUG-011 | Deferred (staged for Spec-09) |
| BUG-012 | **Fixed** |

## Test Plan

- [x] All 314 unit tests pass
- [x] All 17 integration tests pass (with WSI file)
- [x] Ruff linting clean
- [x] Mypy type checking clean
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced font loading diagnostics with fallback warnings for system fonts
  * Improved Hugging Face authentication logging for better debugging visibility
  * Stabilized slide reader initialization with safer attribute management

* **Documentation**
  * Updated bug tracker to reflect resolution of font fallback and authentication logging issues

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->