### PR TITLE
docs: fix bug documentation drift (BUG-002/003/009/012)

### DIFF
--- a/docs/bugs/BUG-002-spec-contradiction-upsample-small-regions.md
+++ b/docs/bugs/BUG-002-spec-contradiction-upsample-small-regions.md
@@ -2,7 +2,7 @@
 
 ## Severity: P2 (Medium Priority) - Spec-05.5 Doc Mismatch
 
-## Status: Fixed (pending merge)
+## Status: **Fixed**
 
 ## Description
 

--- a/docs/bugs/BUG-003-huge-region-no-protection.md
+++ b/docs/bugs/BUG-003-huge-region-no-protection.md
@@ -2,7 +2,7 @@
 
 ## Severity: P1 (High Priority)
 
-## Status: Fixed (pending merge)
+## Status: **Fixed**
 
 ## Description
 


### PR DESCRIPTION
## Summary

Fixes documentation drift identified in senior review:

- **BUG-002**: Update status from "Fixed (pending merge)" to "Fixed"
- **BUG-003**: Update status from "Fixed (pending merge)" to "Fixed"  
- **BUG-009**: Rename "Current Code" to "Original Code (Before Fix)", add Resolution section with actual fixed code
- **BUG-012**: Rename "Current Code" to "Original Code (Before Fix)", add Resolution section with actual fixed code

## Why This Matters

Bug documentation should be the SSOT for what was broken and how it was fixed. Having outdated "Current Code" sections showing buggy code when the fix is already merged creates confusion.

## Changes

| File | Change |
|------|--------|
| `BUG-002-spec-contradiction-upsample-small-regions.md` | Status: "Fixed (pending merge)" → "**Fixed**" |
| `BUG-003-huge-region-no-protection.md` | Status: "Fixed (pending merge)" → "**Fixed**" |
| `BUG-009-font-loading-silent-fallback.md` | Added Resolution section with fixed code |
| `BUG-012-download-silent-auth.md` | Added Resolution section with fixed code |

## Test Plan

- [x] 314 unit tests pass
- [x] Documentation-only changes, no code changes

---

**⚠️ Waiting for senior review before merge.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Font loading now displays warnings when falling back to alternative fonts instead of silently failing.
* Download authentication improved with proper logging when tokens are not configured.

## Documentation
* Updated bug tracking documentation to reflect recently resolved issues and implementation details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->