### PR TITLE
feat(prompts): implement Spec-07 Navigation Prompt Engineering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ ignore = []
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["PLR2004"]  # Allow magic numbers in tests
 "src/giant/llm/pricing.py" = ["PLR0913"]  # Allow many args for calculate_total_cost
+"src/giant/prompts/templates.py" = ["E501"]  # Prompt templates need readable lines
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/giant/prompts/__init__.py
+++ b/src/giant/prompts/__init__.py
@@ -1,0 +1,9 @@
+"""Navigation prompt engineering for GIANT.
+
+This module provides prompt templates and construction logic for guiding
+the LMM through the GIANT navigation task per Spec-07.
+"""
+
+from giant.prompts.builder import PromptBuilder
+
+__all__ = ["PromptBuilder"]

--- a/src/giant/prompts/builder.py
+++ b/src/giant/prompts/builder.py
@@ -1,0 +1,150 @@
+"""Prompt builder for GIANT navigation.
+
+Constructs properly formatted messages for the LLM from templates.
+Implements Spec-07 Navigation Prompt Engineering.
+"""
+
+from giant.llm.protocol import Message, MessageContent
+from giant.prompts.templates import (
+    FINAL_STEP_PROMPT,
+    INITIAL_USER_PROMPT,
+    SUBSEQUENT_USER_PROMPT,
+    SYSTEM_PROMPT,
+)
+
+
+class PromptBuilder:
+    """Builds prompts for GIANT navigation steps.
+
+    Responsible for:
+    - Constructing the system message with navigation instructions
+    - Building user messages with dynamic step state
+    - Including images in the proper format
+
+    Usage:
+        builder = PromptBuilder()
+        system_msg = builder.build_system_message()
+        user_msg = builder.build_user_message(
+            question="Is this tissue malignant?",
+            step=1,
+            max_steps=5,
+            context_images=[thumbnail_base64],
+        )
+    """
+
+    def build_system_message(self) -> Message:
+        """Build the system message with navigation instructions.
+
+        Returns:
+            Message with role='system' containing the GIANT system prompt.
+        """
+        return Message(
+            role="system",
+            content=[
+                MessageContent(
+                    type="text",
+                    text=SYSTEM_PROMPT,
+                )
+            ],
+        )
+
+    def build_user_message(
+        self,
+        question: str,
+        step: int,
+        max_steps: int,
+        context_images: list[str],
+        last_region: str | None = None,
+    ) -> Message:
+        """Build the user message for a navigation step.
+
+        Args:
+            question: The diagnostic question to answer.
+            step: Current step number (1-indexed).
+            max_steps: Total number of steps allowed.
+            context_images: List of base64-encoded images to include.
+            last_region: String description of the last cropped region
+                (e.g., "(1000, 2000, 500, 500)") for subsequent steps.
+
+        Returns:
+            Message with role='user' containing text and images.
+
+        Raises:
+            ValueError: If inputs are invalid (empty question, step out of range).
+        """
+        # Validate inputs
+        if not question or not question.strip():
+            raise ValueError("question must not be empty")
+        if max_steps < 1:
+            raise ValueError("max_steps must be at least 1")
+        if step < 1:
+            raise ValueError("step must be at least 1")
+        if step > max_steps:
+            raise ValueError(f"step ({step}) cannot exceed max_steps ({max_steps})")
+
+        # Build text content
+        text = self._build_prompt_text(question, step, max_steps, last_region)
+
+        # Build message content list
+        content: list[MessageContent] = [
+            MessageContent(type="text", text=text),
+        ]
+
+        # Add images
+        for image_base64 in context_images:
+            content.append(
+                MessageContent(
+                    type="image",
+                    image_base64=image_base64,
+                    media_type="image/jpeg",
+                )
+            )
+
+        return Message(role="user", content=content)
+
+    def _build_prompt_text(
+        self,
+        question: str,
+        step: int,
+        max_steps: int,
+        last_region: str | None,
+    ) -> str:
+        """Build the appropriate prompt text based on step state.
+
+        Args:
+            question: The diagnostic question.
+            step: Current step (1-indexed).
+            max_steps: Total steps allowed.
+            last_region: Description of last cropped region (for subsequent steps).
+
+        Returns:
+            Formatted prompt text string.
+        """
+        remaining_crops = max_steps - step
+
+        # Final step - must answer
+        if step == max_steps:
+            return FINAL_STEP_PROMPT.format(
+                question=question,
+                step=step,
+                max_steps=max_steps,
+            )
+
+        # Initial step (step 1)
+        if step == 1:
+            return INITIAL_USER_PROMPT.format(
+                question=question,
+                step=step,
+                max_steps=max_steps,
+                remaining_crops=remaining_crops,
+                max_steps_minus_one=max_steps - 1,
+            )
+
+        # Subsequent steps (2 to max_steps-1)
+        return SUBSEQUENT_USER_PROMPT.format(
+            question=question,
+            step=step,
+            max_steps=max_steps,
+            remaining_crops=remaining_crops,
+            last_region=last_region or "unknown",
+        )

--- a/src/giant/prompts/templates.py
+++ b/src/giant/prompts/templates.py
@@ -1,0 +1,54 @@
+"""Prompt templates for GIANT navigation.
+
+Raw string templates for system and user prompts. These are designed to be
+paper-faithful to Algorithm 1 from the GIANT paper.
+
+Note: When official prompts become available from the paper's Supplementary
+Material, these templates should be replaced.
+"""
+
+# System prompt template per Spec-07
+SYSTEM_PROMPT = """You are GIANT (Gigapixel Image Agent for Navigating Tissue), an expert computational pathologist assistant.
+
+YOUR GOAL:
+Answer the user's question about a Whole Slide Image (WSI) by iteratively examining regions of interest.
+
+THE IMAGE:
+- You are viewing a gigapixel pathology slide.
+- You cannot see the whole slide in full detail at once.
+- You are currently provided with a view (either the full slide thumbnail or a zoomed-in crop).
+- The thumbnail view has AXIS GUIDES overlaid. These red lines are labeled with ABSOLUTE LEVEL-0 PIXEL COORDINATES (e.g., 10000, 20000).
+- ALL coordinates you output must be in this LEVEL-0 system.
+
+YOUR TOOLS:
+1. `crop(x, y, width, height)`: Zoom into a specific region.
+   - `x`, `y`: Top-left corner in Level-0 coordinates.
+   - `width`, `height`: Dimensions in Level-0 pixels.
+   - Use the axis guides on the thumbnail to estimate these numbers.
+2. `answer(text)`: Provide the final answer to the user's question.
+
+PROCESS:
+1. Analyze the current image. Look for tissue structures relevant to the question.
+2. Provide `reasoning`: Explain what you see and why you need to zoom in or answer.
+3. Choose an `action`:
+   - If you need more detail, choose `crop`.
+   - If you have sufficient evidence, choose `answer`.
+
+CONSTRAINTS:
+- You have a limited number of steps. Make every crop count.
+- If the current view is blurry, it means you are looking at a thumbnail. You MUST zoom in to see cellular details."""
+
+# Initial user prompt template (first step)
+INITIAL_USER_PROMPT = """Question: {question}
+Status: Step {step} of {max_steps}. You have {remaining_crops} crops remaining.
+Instruction: For Steps 1..{max_steps_minus_one} you MUST use `crop`. On Step {max_steps} you MUST use `answer`."""
+
+# Subsequent user prompt template (steps 2+)
+SUBSEQUENT_USER_PROMPT = """Status: Step {step} of {max_steps}. You have {remaining_crops} crops remaining.
+Last Action: You cropped region {last_region}.
+Question: {question}"""
+
+# Final step user prompt template
+FINAL_STEP_PROMPT = """Question: {question}
+Status: Step {step} of {max_steps}. This is your FINAL step.
+Instruction: You MUST use `answer` now to provide your final diagnosis."""

--- a/tests/unit/prompts/__init__.py
+++ b/tests/unit/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for giant.prompts module."""

--- a/tests/unit/prompts/test_builder.py
+++ b/tests/unit/prompts/test_builder.py
@@ -1,0 +1,248 @@
+"""Tests for giant.prompts.builder module.
+
+TDD tests for PromptBuilder following Spec-07 requirements.
+"""
+
+import pytest
+
+from giant.prompts.builder import PromptBuilder
+
+
+class TestPromptBuilderSystemMessage:
+    """Tests for system message construction."""
+
+    def test_system_message_has_correct_role(self) -> None:
+        """Test that system message has role='system'."""
+        builder = PromptBuilder()
+        message = builder.build_system_message()
+        assert message.role == "system"
+
+    def test_system_message_has_text_content(self) -> None:
+        """Test that system message contains text content."""
+        builder = PromptBuilder()
+        message = builder.build_system_message()
+        assert len(message.content) == 1
+        assert message.content[0].type == "text"
+        assert message.content[0].text is not None
+
+    def test_system_message_contains_giant_identity(self) -> None:
+        """Test that system prompt identifies as GIANT."""
+        builder = PromptBuilder()
+        message = builder.build_system_message()
+        text = message.content[0].text or ""
+        assert "GIANT" in text
+        assert "pathologist" in text.lower()
+
+    def test_system_message_explains_coordinate_system(self) -> None:
+        """Test that system prompt explains Level-0 coordinates."""
+        builder = PromptBuilder()
+        message = builder.build_system_message()
+        text = message.content[0].text or ""
+        assert "Level-0" in text or "level-0" in text.lower()
+
+    def test_system_message_mentions_axis_guides(self) -> None:
+        """Test that system prompt mentions axis guides."""
+        builder = PromptBuilder()
+        message = builder.build_system_message()
+        text = message.content[0].text or ""
+        assert "axis" in text.lower() and "guide" in text.lower()
+
+    def test_system_message_describes_crop_tool(self) -> None:
+        """Test that system prompt describes the crop tool."""
+        builder = PromptBuilder()
+        message = builder.build_system_message()
+        text = message.content[0].text or ""
+        assert "crop" in text.lower()
+        # Should mention coordinates
+        assert "x" in text.lower() and "y" in text.lower()
+
+    def test_system_message_describes_answer_tool(self) -> None:
+        """Test that system prompt describes the answer tool."""
+        builder = PromptBuilder()
+        message = builder.build_system_message()
+        text = message.content[0].text or ""
+        assert "answer" in text.lower()
+
+
+class TestPromptBuilderUserMessage:
+    """Tests for user message construction."""
+
+    def test_user_message_has_correct_role(self) -> None:
+        """Test that user message has role='user'."""
+        builder = PromptBuilder()
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=1,
+            max_steps=5,
+            context_images=[],
+        )
+        assert message.role == "user"
+
+    def test_user_message_includes_question(self) -> None:
+        """Test that user message includes the question."""
+        builder = PromptBuilder()
+        question = "Is this tissue malignant?"
+        message = builder.build_user_message(
+            question=question,
+            step=1,
+            max_steps=5,
+            context_images=[],
+        )
+        # Find text content
+        text_content = next(c for c in message.content if c.type == "text")
+        assert question in (text_content.text or "")
+
+    def test_user_message_includes_step_status(self) -> None:
+        """Test that user message includes step X of Y status."""
+        builder = PromptBuilder()
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=2,
+            max_steps=7,
+            context_images=[],
+        )
+        text_content = next(c for c in message.content if c.type == "text")
+        text = text_content.text or ""
+        # Should mention step 2 and max 7
+        assert "2" in text
+        assert "7" in text
+
+    def test_user_message_includes_remaining_crops(self) -> None:
+        """Test that user message shows remaining crops."""
+        builder = PromptBuilder()
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=1,
+            max_steps=5,
+            context_images=[],
+        )
+        text_content = next(c for c in message.content if c.type == "text")
+        text = text_content.text or ""
+        # Step 1 of 5 means 4 crops remaining (paper: "at most T-1 crops")
+        assert "4" in text and "remaining" in text.lower()
+
+    def test_user_message_includes_images(self) -> None:
+        """Test that user message includes context images."""
+        builder = PromptBuilder()
+        # Fake base64 images
+        images = ["base64image1==", "base64image2=="]
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=1,
+            max_steps=5,
+            context_images=images,
+        )
+        # Should have text + images
+        image_contents = [c for c in message.content if c.type == "image"]
+        assert len(image_contents) == 2
+        assert image_contents[0].image_base64 == "base64image1=="
+        assert image_contents[1].image_base64 == "base64image2=="
+
+    def test_user_message_initial_step_instruction(self) -> None:
+        """Test that initial step has crop instruction."""
+        builder = PromptBuilder()
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=1,
+            max_steps=5,
+            context_images=[],
+        )
+        text_content = next(c for c in message.content if c.type == "text")
+        text = text_content.text or ""
+        # Per spec: "For Steps 1..{max_steps - 1} you MUST use crop"
+        assert "crop" in text.lower()
+
+    def test_user_message_final_step_forces_answer(self) -> None:
+        """Test that final step requires answer."""
+        builder = PromptBuilder()
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=5,
+            max_steps=5,
+            context_images=[],
+        )
+        text_content = next(c for c in message.content if c.type == "text")
+        text = text_content.text or ""
+        # Final step should mention must answer
+        assert "answer" in text.lower()
+        # Should indicate this is final
+        assert "must" in text.lower() or "final" in text.lower()
+
+
+class TestPromptBuilderSubsequentSteps:
+    """Tests for subsequent step message variations."""
+
+    def test_subsequent_step_mentions_last_action(self) -> None:
+        """Test that subsequent steps can mention last action."""
+        builder = PromptBuilder()
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=2,
+            max_steps=5,
+            context_images=["base64crop=="],
+            last_region="(1000, 2000, 500, 500)",
+        )
+        text_content = next(c for c in message.content if c.type == "text")
+        text = text_content.text or ""
+        # Should mention the last region
+        assert "1000" in text or "crop" in text.lower()
+
+    def test_image_media_type_is_jpeg(self) -> None:
+        """Test that image content has correct media type."""
+        builder = PromptBuilder()
+        message = builder.build_user_message(
+            question="What is the diagnosis?",
+            step=1,
+            max_steps=5,
+            context_images=["base64image=="],
+        )
+        image_content = next(c for c in message.content if c.type == "image")
+        assert image_content.media_type == "image/jpeg"
+
+
+class TestPromptBuilderEdgeCases:
+    """Tests for edge cases and validation."""
+
+    def test_empty_question_raises(self) -> None:
+        """Test that empty question raises ValueError."""
+        builder = PromptBuilder()
+        with pytest.raises(ValueError, match="question"):
+            builder.build_user_message(
+                question="",
+                step=1,
+                max_steps=5,
+                context_images=[],
+            )
+
+    def test_step_exceeds_max_raises(self) -> None:
+        """Test that step > max_steps raises ValueError."""
+        builder = PromptBuilder()
+        with pytest.raises(ValueError, match="step"):
+            builder.build_user_message(
+                question="What is the diagnosis?",
+                step=6,
+                max_steps=5,
+                context_images=[],
+            )
+
+    def test_zero_step_raises(self) -> None:
+        """Test that step 0 raises ValueError."""
+        builder = PromptBuilder()
+        with pytest.raises(ValueError, match="step"):
+            builder.build_user_message(
+                question="What is the diagnosis?",
+                step=0,
+                max_steps=5,
+                context_images=[],
+            )
+
+    def test_max_steps_less_than_one_raises(self) -> None:
+        """Test that max_steps < 1 raises ValueError."""
+        builder = PromptBuilder()
+        with pytest.raises(ValueError, match="max_steps"):
+            builder.build_user_message(
+                question="What is the diagnosis?",
+                step=1,
+                max_steps=0,
+                context_images=[],
+            )


### PR DESCRIPTION
## Summary
- Implements `PromptBuilder` class for constructing navigation prompts per Spec-07
- System prompt establishes GIANT pathologist persona with Level-0 coordinate system
- User prompts track step state (Step X of Y, N crops remaining)
- Final step enforces `answer` action

## Implementation Details
- **System prompt**: GIANT identity, axis guides, crop/answer tools, process constraints
- **User prompts**: Dynamic state tracking, image support, question integration
- **Validation**: Empty question, step bounds, max_steps validation

## Test Plan
- [x] 20 unit tests covering all acceptance criteria
- [x] TDD Red-Green cycle followed
- [x] ruff clean
- [x] mypy clean
- [x] 500 total tests passing

## Files Changed
```
src/giant/prompts/
├── __init__.py
├── builder.py      # PromptBuilder class
└── templates.py    # System/user prompt templates
tests/unit/prompts/
└── test_builder.py # 20 unit tests
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New prompt generation framework enabling dynamic construction of navigation instructions with multi-step workflows, contextual image integration, and adaptive guidance based on step progression.

* **Tests**
  * Comprehensive test coverage added for prompt generation, validating message structure, step logic, image attachment, and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->