### PR TITLE
feat(agent): implement Spec-08 Conversation Context Manager

### DIFF
--- a/src/giant/agent/__init__.py
+++ b/src/giant/agent/__init__.py
@@ -1,0 +1,11 @@
+"""Agent module for GIANT navigation.
+
+This module provides the core agent components including:
+- Trajectory tracking and serialization
+- Conversation context management
+"""
+
+from giant.agent.context import ContextManager
+from giant.agent.trajectory import Trajectory, Turn
+
+__all__ = ["ContextManager", "Trajectory", "Turn"]

--- a/src/giant/agent/context.py
+++ b/src/giant/agent/context.py
@@ -1,0 +1,290 @@
+"""Context manager for GIANT navigation.
+
+Manages conversation state and message construction for the LLM.
+Implements Spec-08 Conversation Context Manager.
+
+The ContextManager:
+- Tracks the full navigation trajectory
+- Constructs properly formatted messages for the LLM
+- Optionally prunes old images to manage context window size
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from giant.agent.trajectory import Trajectory, Turn
+from giant.geometry.primitives import Region
+from giant.llm.protocol import (
+    FinalAnswerAction,
+    Message,
+    MessageContent,
+    StepResponse,
+)
+from giant.prompts.builder import PromptBuilder
+
+
+@dataclass
+class ContextManager:
+    """Manages navigation context and message history.
+
+    Responsible for:
+    - Tracking the agent's trajectory (observations, reasoning, actions)
+    - Constructing LLM messages with proper alternation (user/assistant)
+    - Pruning old images when history limit is exceeded
+
+    Usage:
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Is this malignant?",
+            max_steps=5,
+        )
+        ctx.add_turn(image_base64=thumbnail, response=response)
+        messages = ctx.get_messages(thumbnail_base64=thumbnail)
+    """
+
+    wsi_path: str
+    question: str
+    max_steps: int
+    max_history_images: int | None = None
+
+    trajectory: Trajectory = field(init=False)
+    _prompt_builder: PromptBuilder = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize trajectory and prompt builder."""
+        self.trajectory = Trajectory(
+            wsi_path=self.wsi_path,
+            question=self.question,
+        )
+        self._prompt_builder = PromptBuilder()
+
+    @property
+    def current_step(self) -> int:
+        """Get the current step number (1-indexed).
+
+        Returns:
+            Current step number starting from 1.
+        """
+        return len(self.trajectory.turns) + 1
+
+    @property
+    def is_final_step(self) -> bool:
+        """Check if we're at the final step.
+
+        Returns:
+            True if current step equals max_steps.
+        """
+        return self.current_step == self.max_steps
+
+    def add_turn(
+        self,
+        image_base64: str,
+        response: StepResponse,
+        region: Region | None = None,
+    ) -> None:
+        """Add a navigation turn to the trajectory.
+
+        Args:
+            image_base64: Base64-encoded image for this step.
+            response: The model's reasoning and action.
+            region: The region that was cropped (None for thumbnail).
+        """
+        turn = Turn(
+            step_index=len(self.trajectory.turns),
+            image_base64=image_base64,
+            response=response,
+            region=region,
+        )
+        self.trajectory.turns.append(turn)
+
+        # Set final answer if this was an answer action
+        if isinstance(response.action, FinalAnswerAction):
+            self.trajectory.final_answer = response.action.answer_text
+
+    def get_messages(self, thumbnail_base64: str) -> list[Message]:
+        """Construct the full message history for the LLM.
+
+        Builds a properly formatted conversation with:
+        1. System message (navigation instructions)
+        2. Initial user message (question + thumbnail)
+        3. Alternating assistant/user messages for each turn
+
+        Args:
+            thumbnail_base64: Base64-encoded thumbnail image.
+
+        Returns:
+            List of Messages ready for the LLM provider.
+        """
+        messages: list[Message] = []
+
+        # 1. System message
+        messages.append(self._prompt_builder.build_system_message())
+
+        # 2. Initial user message with question and thumbnail
+        messages.append(
+            self._prompt_builder.build_user_message(
+                question=self.question,
+                step=1,
+                max_steps=self.max_steps,
+                context_images=[thumbnail_base64],
+            )
+        )
+
+        # 3. Add turns as alternating assistant/user messages
+        for i, turn in enumerate(self.trajectory.turns):
+            # Assistant message: reasoning + action
+            messages.append(self._build_assistant_message(turn))
+
+            # If not the last turn, add user message for next step
+            if i < len(self.trajectory.turns) - 1:
+                next_turn = self.trajectory.turns[i + 1]
+                messages.append(
+                    self._build_user_message_for_turn(
+                        turn=next_turn,
+                        step=i + 2,  # 1-indexed, +1 for next step
+                    )
+                )
+            elif i == len(self.trajectory.turns) - 1:
+                # Last turn: no additional user message needed
+                pass
+
+        # Apply image pruning if configured
+        if self.max_history_images is not None:
+            messages = self._apply_image_pruning(messages, thumbnail_base64)
+
+        return messages
+
+    def _build_assistant_message(self, turn: Turn) -> Message:
+        """Build assistant message from a turn.
+
+        Args:
+            turn: The turn to build message from.
+
+        Returns:
+            Message with role='assistant'.
+        """
+        # Format the assistant response as text
+        action = turn.response.action
+        if hasattr(action, "action_type"):
+            if action.action_type == "crop":
+                action_text = (
+                    f"crop(x={action.x}, y={action.y}, "
+                    f"width={action.width}, height={action.height})"
+                )
+            else:
+                action_text = f'answer("{action.answer_text}")'
+        else:
+            action_text = str(action)
+
+        text = f"Reasoning: {turn.response.reasoning}\n\nAction: {action_text}"
+
+        return Message(
+            role="assistant",
+            content=[MessageContent(type="text", text=text)],
+        )
+
+    def _build_user_message_for_turn(self, turn: Turn, step: int) -> Message:
+        """Build user message for a subsequent turn.
+
+        Args:
+            turn: The turn containing the crop image.
+            step: The step number (1-indexed).
+
+        Returns:
+            Message with role='user' containing crop image.
+        """
+        # Format region string if available
+        last_region = None
+        if turn.region is not None:
+            r = turn.region
+            last_region = f"({r.x}, {r.y}, {r.width}, {r.height})"
+
+        return self._prompt_builder.build_user_message(
+            question=self.question,
+            step=step,
+            max_steps=self.max_steps,
+            context_images=[turn.image_base64],
+            last_region=last_region,
+        )
+
+    def _apply_image_pruning(
+        self,
+        messages: list[Message],
+        thumbnail_base64: str,
+    ) -> list[Message]:
+        """Apply image pruning to keep context window manageable.
+
+        Keeps:
+        - Thumbnail (always, in first user message)
+        - Last N crop images (where N = max_history_images)
+
+        Replaces pruned images with placeholder text.
+
+        Args:
+            messages: List of messages to prune.
+            thumbnail_base64: Thumbnail to always keep.
+
+        Returns:
+            Pruned message list.
+        """
+        if self.max_history_images is None:
+            return messages
+
+        # Count how many crop images we have (excluding thumbnail)
+        crop_count = len(self.trajectory.turns)
+        if crop_count <= self.max_history_images:
+            return messages
+
+        # Calculate which turns to prune (keep last N)
+        turns_to_keep = set(range(crop_count - self.max_history_images, crop_count))
+
+        # Prune images from user messages (after the initial one)
+        pruned_messages: list[Message] = []
+        user_msg_index = 0
+
+        for msg in messages:
+            if msg.role == "user":
+                if user_msg_index == 0:
+                    # First user message - keep thumbnail
+                    pruned_messages.append(msg)
+                else:
+                    # Subsequent user messages - check if should prune
+                    # user_msg[k] contains turn[k].image for k > 0
+                    turn_index = user_msg_index
+                    if turn_index not in turns_to_keep:
+                        # Prune: replace image with placeholder
+                        pruned_messages.append(
+                            self._prune_images_from_message(msg, turn_index)
+                        )
+                    else:
+                        pruned_messages.append(msg)
+                user_msg_index += 1
+            else:
+                pruned_messages.append(msg)
+
+        return pruned_messages
+
+    def _prune_images_from_message(self, msg: Message, step_index: int) -> Message:
+        """Replace images in a message with placeholder text.
+
+        Args:
+            msg: Message to prune images from.
+            step_index: Step index for placeholder text.
+
+        Returns:
+            New message with images replaced by placeholder.
+        """
+        new_content: list[MessageContent] = []
+
+        for content in msg.content:
+            if content.type == "image":
+                # Replace with placeholder text
+                placeholder = (
+                    f"[Image from Step {step_index + 1} removed to save context]"
+                )
+                new_content.append(MessageContent(type="text", text=placeholder))
+            else:
+                new_content.append(content)
+
+        return Message(role=msg.role, content=new_content)

--- a/src/giant/agent/trajectory.py
+++ b/src/giant/agent/trajectory.py
@@ -1,0 +1,63 @@
+"""Trajectory models for GIANT navigation.
+
+Data models for tracking the agent's navigation history. These models
+provide serializable representations of the navigation session for
+visualization, analysis, and debugging.
+
+Per Spec-08:
+- Turn stores a single step's observation, reasoning, and action
+- Trajectory stores the full navigation history
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from giant.geometry.primitives import Region
+from giant.llm.protocol import StepResponse
+
+
+class Turn(BaseModel):
+    """A single navigation turn in the agent's trajectory.
+
+    Represents one step of the navigation process including the image
+    observed, the model's reasoning, and the action taken.
+
+    Attributes:
+        step_index: Zero-indexed step number in the trajectory.
+        image_base64: Base64-encoded image observed at this step.
+        response: The model's reasoning and action for this step.
+        region: The region that was cropped to produce this view
+            (None for initial thumbnail).
+    """
+
+    step_index: int = Field(..., ge=0, description="Zero-indexed step number")
+    image_base64: str = Field(..., description="Base64-encoded image")
+    response: StepResponse = Field(..., description="Model's reasoning and action")
+    region: Region | None = Field(
+        default=None,
+        description="Region that was cropped (None for thumbnail)",
+    )
+
+
+class Trajectory(BaseModel):
+    """Complete navigation trajectory for a WSI analysis session.
+
+    Stores the full history of observations, reasoning, and actions
+    taken by the agent. Can be serialized to JSON for visualization
+    and analysis.
+
+    Attributes:
+        wsi_path: Path to the Whole Slide Image being analyzed.
+        question: The diagnostic question being answered.
+        turns: List of navigation turns in chronological order.
+        final_answer: The agent's final answer (if completed).
+    """
+
+    wsi_path: str = Field(..., description="Path to the WSI file")
+    question: str = Field(..., description="Diagnostic question")
+    turns: list[Turn] = Field(default_factory=list, description="Navigation turns")
+    final_answer: str | None = Field(
+        default=None,
+        description="Final answer (if completed)",
+    )

--- a/tests/unit/agent/__init__.py
+++ b/tests/unit/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for giant.agent module."""

--- a/tests/unit/agent/test_context.py
+++ b/tests/unit/agent/test_context.py
@@ -1,0 +1,372 @@
+"""Tests for giant.agent.context module.
+
+TDD tests for ContextManager following Spec-08.
+"""
+
+from giant.agent.context import ContextManager
+from giant.geometry.primitives import Region
+from giant.llm.protocol import BoundingBoxAction, FinalAnswerAction, StepResponse
+
+
+class TestContextManagerInit:
+    """Tests for ContextManager initialization."""
+
+    def test_init_creates_empty_trajectory(self) -> None:
+        """Test that initialization creates empty trajectory."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="What is this?",
+            max_steps=5,
+        )
+        assert ctx.trajectory.wsi_path == "/slide.svs"
+        assert ctx.trajectory.question == "What is this?"
+        assert len(ctx.trajectory.turns) == 0
+
+    def test_init_with_default_max_history_images(self) -> None:
+        """Test that max_history_images defaults to None (keep all)."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        assert ctx.max_history_images is None
+
+    def test_init_with_custom_max_history_images(self) -> None:
+        """Test initialization with custom image limit."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+            max_history_images=3,
+        )
+        assert ctx.max_history_images == 3
+
+
+class TestContextManagerAddTurn:
+    """Tests for ContextManager.add_turn method."""
+
+    def test_add_turn_appends_to_trajectory(self) -> None:
+        """Test that add_turn adds a turn to trajectory."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        response = StepResponse(
+            reasoning="Found region",
+            action=BoundingBoxAction(x=100, y=200, width=300, height=400),
+        )
+        ctx.add_turn(
+            image_base64="thumb==",
+            response=response,
+        )
+        assert len(ctx.trajectory.turns) == 1
+        assert ctx.trajectory.turns[0].step_index == 0
+
+    def test_add_turn_increments_step_index(self) -> None:
+        """Test that step index increments with each turn."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        for i in range(3):
+            response = StepResponse(
+                reasoning=f"Step {i}",
+                action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+            )
+            ctx.add_turn(image_base64=f"img{i}==", response=response)
+
+        assert ctx.trajectory.turns[0].step_index == 0
+        assert ctx.trajectory.turns[1].step_index == 1
+        assert ctx.trajectory.turns[2].step_index == 2
+
+    def test_add_turn_with_region(self) -> None:
+        """Test adding turn with region reference."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        response = StepResponse(
+            reasoning="Crop",
+            action=BoundingBoxAction(x=50, y=50, width=100, height=100),
+        )
+        region = Region(x=1000, y=2000, width=500, height=500)
+        ctx.add_turn(
+            image_base64="crop==",
+            response=response,
+            region=region,
+        )
+        assert ctx.trajectory.turns[0].region == region
+
+    def test_add_turn_sets_final_answer(self) -> None:
+        """Test that final answer action sets trajectory.final_answer."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        response = StepResponse(
+            reasoning="Done",
+            action=FinalAnswerAction(answer_text="Malignant"),
+        )
+        ctx.add_turn(image_base64="img==", response=response)
+        assert ctx.trajectory.final_answer == "Malignant"
+
+
+class TestContextManagerGetMessages:
+    """Tests for ContextManager.get_messages method."""
+
+    def test_get_messages_returns_system_and_user(self) -> None:
+        """Test that get_messages includes system and user messages."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="What is this?",
+            max_steps=5,
+        )
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # Should have system + user messages
+        assert len(messages) >= 2
+        assert messages[0].role == "system"
+        assert messages[1].role == "user"
+
+    def test_get_messages_initial_includes_question(self) -> None:
+        """Test that initial message includes the question."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Is this malignant?",
+            max_steps=5,
+        )
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # Find text in user message
+        user_msg = messages[1]
+        text_content = next(c for c in user_msg.content if c.type == "text")
+        assert "Is this malignant?" in (text_content.text or "")
+
+    def test_get_messages_includes_thumbnail_image(self) -> None:
+        """Test that initial message includes thumbnail image."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        messages = ctx.get_messages(thumbnail_base64="thumbnaildata==")
+
+        user_msg = messages[1]
+        image_contents = [c for c in user_msg.content if c.type == "image"]
+        assert len(image_contents) == 1
+        assert image_contents[0].image_base64 == "thumbnaildata=="
+
+    def test_get_messages_alternates_user_assistant(self) -> None:
+        """Test that messages alternate user/assistant after turns."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        # Add a turn
+        response = StepResponse(
+            reasoning="Zoom in",
+            action=BoundingBoxAction(x=100, y=100, width=200, height=200),
+        )
+        ctx.add_turn(image_base64="thumb==", response=response)
+
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # Structure: system, user (initial), assistant (turn 0 response)
+        assert messages[0].role == "system"
+        assert messages[1].role == "user"
+        assert messages[2].role == "assistant"
+
+    def test_get_messages_three_turns_structure(self) -> None:
+        """Test message structure with 3 turns."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        # Add 3 turns
+        for i in range(3):
+            response = StepResponse(
+                reasoning=f"Step {i}",
+                action=BoundingBoxAction(x=i * 100, y=i * 100, width=100, height=100),
+            )
+            ctx.add_turn(image_base64=f"img{i}==", response=response)
+
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # Structure: system, user0, assistant0, user1, assistant1, user2, assistant2
+        # Wait, after turn 0 we have:
+        # - system
+        # - user (initial with thumb)
+        # - assistant (turn 0 reasoning/action)
+        # After turn 1:
+        # - user (crop 1)
+        # - assistant (turn 1)
+        # etc.
+        # So with 3 turns: system + 6 messages = 7 total
+        assert len(messages) == 7
+        roles = [m.role for m in messages]
+        assert roles == [
+            "system",
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+        ]
+
+
+class TestContextManagerImagePruning:
+    """Tests for image history pruning."""
+
+    def test_no_pruning_when_limit_is_none(self) -> None:
+        """Test all images kept when max_history_images is None."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=10,
+            max_history_images=None,
+        )
+        # Add 5 turns
+        for i in range(5):
+            response = StepResponse(
+                reasoning=f"Step {i}",
+                action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+            )
+            ctx.add_turn(image_base64=f"img{i}==", response=response)
+
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # All images should be present
+        image_count = sum(1 for m in messages for c in m.content if c.type == "image")
+        # Thumbnail + 4 crop images (turn 0 sees thumb, turns 1-4 see crops)
+        assert image_count == 5
+
+    def test_pruning_removes_old_images(self) -> None:
+        """Test that old images are replaced with placeholder text."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=10,
+            max_history_images=2,
+        )
+        # Add 5 turns
+        for i in range(5):
+            response = StepResponse(
+                reasoning=f"Step {i}",
+                action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+            )
+            ctx.add_turn(image_base64=f"img{i}==", response=response)
+
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # Should have: thumbnail (always) + last 2 crops = 3 images
+        image_count = sum(1 for m in messages for c in m.content if c.type == "image")
+        assert image_count == 3
+
+    def test_pruning_keeps_thumbnail_always(self) -> None:
+        """Test that thumbnail is never pruned."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=10,
+            max_history_images=1,
+        )
+        # Add 5 turns
+        for i in range(5):
+            response = StepResponse(
+                reasoning=f"Step {i}",
+                action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+            )
+            ctx.add_turn(image_base64=f"img{i}==", response=response)
+
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # First user message should still have thumbnail
+        user_msg = messages[1]
+        image_contents = [c for c in user_msg.content if c.type == "image"]
+        assert len(image_contents) == 1
+        assert image_contents[0].image_base64 == "thumb=="
+
+    def test_pruned_messages_have_placeholder_text(self) -> None:
+        """Test that pruned images are replaced with placeholder."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=10,
+            max_history_images=1,
+        )
+        # Add 3 turns
+        for i in range(3):
+            response = StepResponse(
+                reasoning=f"Step {i}",
+                action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+            )
+            ctx.add_turn(image_base64=f"img{i}==", response=response)
+
+        messages = ctx.get_messages(thumbnail_base64="thumb==")
+
+        # Find pruned message (should be the second user message, turn 1)
+        # The placeholder should mention "removed"
+        user_messages = [m for m in messages if m.role == "user"]
+        # First user (initial) has thumbnail, second user (turn 1) should be pruned
+        assert len(user_messages) > 1
+        pruned_msg = user_messages[1]
+        # Pruned message should have no images
+        image_contents = [c for c in pruned_msg.content if c.type == "image"]
+        assert len(image_contents) == 0
+        # Should have placeholder text mentioning removal
+        all_text = " ".join(
+            c.text or "" for c in pruned_msg.content if c.type == "text"
+        )
+        assert "removed" in all_text.lower()
+
+
+class TestContextManagerCurrentStep:
+    """Tests for current step tracking."""
+
+    def test_current_step_starts_at_one(self) -> None:
+        """Test that current step starts at 1 (1-indexed)."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        assert ctx.current_step == 1
+
+    def test_current_step_increments_after_add_turn(self) -> None:
+        """Test that current step increments after adding turn."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=5,
+        )
+        response = StepResponse(
+            reasoning="Step",
+            action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+        )
+        ctx.add_turn(image_base64="img==", response=response)
+        assert ctx.current_step == 2
+
+    def test_is_final_step(self) -> None:
+        """Test is_final_step property."""
+        ctx = ContextManager(
+            wsi_path="/slide.svs",
+            question="Q?",
+            max_steps=3,
+        )
+        assert not ctx.is_final_step
+        # Add 2 turns
+        for _ in range(2):
+            response = StepResponse(
+                reasoning="Step",
+                action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+            )
+            ctx.add_turn(image_base64="img==", response=response)
+        # Now at step 3 of 3
+        assert ctx.is_final_step

--- a/tests/unit/agent/test_trajectory.py
+++ b/tests/unit/agent/test_trajectory.py
@@ -1,0 +1,150 @@
+"""Tests for giant.agent.trajectory module.
+
+TDD tests for Turn and Trajectory data models following Spec-08.
+"""
+
+import json
+
+from giant.agent.trajectory import Trajectory, Turn
+from giant.geometry.primitives import Region
+from giant.llm.protocol import BoundingBoxAction, FinalAnswerAction, StepResponse
+
+
+class TestTurnModel:
+    """Tests for Turn data model."""
+
+    def test_turn_creation_with_crop_action(self) -> None:
+        """Test creating a turn with crop action."""
+        response = StepResponse(
+            reasoning="I see a suspicious region",
+            action=BoundingBoxAction(x=100, y=200, width=300, height=400),
+        )
+        turn = Turn(
+            step_index=0,
+            image_base64="base64data==",
+            response=response,
+            region=None,
+        )
+        assert turn.step_index == 0
+        assert turn.image_base64 == "base64data=="
+        assert turn.response.reasoning == "I see a suspicious region"
+        assert turn.region is None
+
+    def test_turn_creation_with_region(self) -> None:
+        """Test creating a turn with a region reference."""
+        response = StepResponse(
+            reasoning="Zooming in",
+            action=BoundingBoxAction(x=50, y=50, width=100, height=100),
+        )
+        region = Region(x=1000, y=2000, width=500, height=500)
+        turn = Turn(
+            step_index=1,
+            image_base64="cropdata==",
+            response=response,
+            region=region,
+        )
+        assert turn.region is not None
+        assert turn.region.x == 1000
+
+    def test_turn_serialization(self) -> None:
+        """Test that Turn serializes to JSON."""
+        response = StepResponse(
+            reasoning="Analysis",
+            action=FinalAnswerAction(answer_text="Benign"),
+        )
+        turn = Turn(
+            step_index=2,
+            image_base64="data==",
+            response=response,
+        )
+        json_str = turn.model_dump_json()
+        assert "step_index" in json_str
+        assert "Benign" in json_str
+
+
+class TestTrajectoryModel:
+    """Tests for Trajectory data model."""
+
+    def test_trajectory_creation(self) -> None:
+        """Test creating an empty trajectory."""
+        trajectory = Trajectory(
+            wsi_path="/path/to/slide.svs",
+            question="Is this malignant?",
+        )
+        assert trajectory.wsi_path == "/path/to/slide.svs"
+        assert trajectory.question == "Is this malignant?"
+        assert trajectory.turns == []
+        assert trajectory.final_answer is None
+
+    def test_trajectory_with_turns(self) -> None:
+        """Test trajectory with multiple turns."""
+        turn1 = Turn(
+            step_index=0,
+            image_base64="thumb==",
+            response=StepResponse(
+                reasoning="Start",
+                action=BoundingBoxAction(x=100, y=100, width=200, height=200),
+            ),
+        )
+        turn2 = Turn(
+            step_index=1,
+            image_base64="crop1==",
+            response=StepResponse(
+                reasoning="End",
+                action=FinalAnswerAction(answer_text="Benign"),
+            ),
+            region=Region(x=100, y=100, width=200, height=200),
+        )
+        trajectory = Trajectory(
+            wsi_path="/slide.svs",
+            question="Diagnosis?",
+            turns=[turn1, turn2],
+            final_answer="Benign",
+        )
+        assert len(trajectory.turns) == 2
+        assert trajectory.final_answer == "Benign"
+
+    def test_trajectory_serialization_to_json(self) -> None:
+        """Test that Trajectory serializes to valid JSON."""
+        trajectory = Trajectory(
+            wsi_path="/slide.svs",
+            question="What is this?",
+            turns=[
+                Turn(
+                    step_index=0,
+                    image_base64="thumb==",
+                    response=StepResponse(
+                        reasoning="Looking",
+                        action=BoundingBoxAction(x=0, y=0, width=100, height=100),
+                    ),
+                ),
+            ],
+        )
+        json_str = trajectory.model_dump_json()
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert parsed["wsi_path"] == "/slide.svs"
+        assert len(parsed["turns"]) == 1
+
+    def test_trajectory_deserialization_from_json(self) -> None:
+        """Test that Trajectory can be loaded from JSON."""
+        json_data = {
+            "wsi_path": "/test.svs",
+            "question": "Test?",
+            "turns": [
+                {
+                    "step_index": 0,
+                    "image_base64": "data==",
+                    "response": {
+                        "reasoning": "Test",
+                        "action": {"action_type": "answer", "answer_text": "Done"},
+                    },
+                    "region": None,
+                }
+            ],
+            "final_answer": "Done",
+        }
+        trajectory = Trajectory.model_validate(json_data)
+        assert trajectory.wsi_path == "/test.svs"
+        assert trajectory.final_answer == "Done"
+        assert len(trajectory.turns) == 1


### PR DESCRIPTION
## Summary
- Implements `ContextManager` class for managing navigation state per Spec-08
- `Turn` and `Trajectory` models for serializable navigation history
- Message construction with proper user/assistant alternation
- Optional image pruning for context window management

## Implementation Details

**Turn Model:**
- Stores step_index, image_base64, response (StepResponse), and optional region
- Serializable via Pydantic for trajectory visualization

**Trajectory Model:**
- Tracks wsi_path, question, turns list, and final_answer
- Full JSON serialization support for `giant visualize` command

**ContextManager:**
- `add_turn()`: Records observations, reasoning, and actions
- `get_messages()`: Constructs LLM-ready message history
- `max_history_images`: Optional pruning (keeps thumbnail + last N crops)
- Pruned images replaced with `[Image from Step X removed to save context]`

## Test Plan
- [x] 26 unit tests covering all acceptance criteria
- [x] TDD Red-Green cycle followed
- [x] ruff clean
- [x] mypy clean
- [x] 526 total tests passing

## Files Changed
```
src/giant/agent/
├── __init__.py
├── context.py      # ContextManager implementation
└── trajectory.py   # Turn and Trajectory models
tests/unit/agent/
├── test_context.py  # 19 tests
└── test_trajectory.py # 7 tests
```